### PR TITLE
define base runtime images

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,21 @@
+## Build python37 runtime
+- name: 'gcr.io/cloud-builders/docker'
+  args: [ 'build', '-t', 'gcr.io/$PROJECT_ID/knative-lambda-python37:$REVISION_ID', '-t', 'gcr.io/$PROJECT_ID/knative-lambda-python37:latest', '-f' ,'./python-3.7/Dockerfile', '.' ]
+
+## Build python27 runtime
+- name: 'gcr.io/cloud-builders/docker'
+  args: [ 'build', '-t', 'gcr.io/$PROJECT_ID/knative-lambda-python27:$REVISION_ID', '-t', 'gcr.io/$PROJECT_ID/knative-lambda-python27:latest', '-f' ,'./python-2.7/Dockerfile', '.' ]
+
+## Build node4 runtime
+- name: 'gcr.io/cloud-builders/docker'
+  args: [ 'build', '-t', 'gcr.io/$PROJECT_ID/knative-lambda-node4:$REVISION_ID', '-t', 'gcr.io/$PROJECT_ID/knative-lambda-node4:latest', '-f' ,'./node-4.x/Dockerfile', '.' ]
+
+## Build node10 runtime
+- name: 'gcr.io/cloud-builders/docker'
+  args: [ 'build', '-t', 'gcr.io/$PROJECT_ID/knative-lambda-node10:$REVISION_ID', '-t', 'gcr.io/$PROJECT_ID/knative-lambda-node10:latest', '-f' ,'./node-10.x/Dockerfile', '.' ]
+
+images: 
+  - 'gcr.io/$PROJECT_ID/knative-lambda-python37'
+  - 'gcr.io/$PROJECT_ID/knative-lambda-python27'
+  - 'gcr.io/$PROJECT_ID/knative-lambda-node4'
+  - 'gcr.io/$PROJECT_ID/knative-lambda-node10'

--- a/node-10.x/Dockerfile
+++ b/node-10.x/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:10-alpine
+WORKDIR /opt
+
+RUN apk --no-cache add curl \
+    && API_VERSION=\$(curl -sI https://github.com/triggermesh/aws-custom-runtime/releases/latest | grep "Location:" | awk -F "/" '{print \$NF}' | tr -d "\r") \
+    && RUNTIME_VERSION=\$(curl -sI https://github.com/triggermesh/knative-lambda-runtime/releases/latest | grep "Location:" | awk -F "/" '{print \$NF}' | tr -d "\r") \
+    && curl -sL https://github.com/triggermesh/aws-custom-runtime/releases/download/\${API_VERSION}/aws-custom-runtime > aws-custom-runtime \
+    && chmod +x aws-custom-runtime \
+    && curl -sL https://github.com/triggermesh/knative-lambda-runtime/archive/\${RUNTIME_VERSION}.tar.gz | tar -xz knative-lambda-runtime-\${RUNTIME_VERSION}/node-10.x \
+    && mv knative-lambda-runtime-\${RUNTIME_VERSION}/node-10.x/* .
+
+ENV LAMBDA_TASK_ROOT "/opt"

--- a/node-10.x/buildtemplate.yaml
+++ b/node-10.x/buildtemplate.yaml
@@ -38,18 +38,7 @@ spec:
     - |
       cd /workspace/${DIRECTORY}
       cat <<EOF > Dockerfile
-        FROM node:10-alpine
-        WORKDIR /opt
-
-        RUN apk --no-cache add curl \
-          && API_VERSION=\$(curl -sI https://github.com/triggermesh/aws-custom-runtime/releases/latest | grep "Location:" | awk -F "/" '{print \$NF}' | tr -d "\r") \
-          && RUNTIME_VERSION=\$(curl -sI https://github.com/triggermesh/knative-lambda-runtime/releases/latest | grep "Location:" | awk -F "/" '{print \$NF}' | tr -d "\r") \
-          && curl -sL https://github.com/triggermesh/aws-custom-runtime/releases/download/\${API_VERSION}/aws-custom-runtime > aws-custom-runtime \
-          && chmod +x aws-custom-runtime \
-          && curl -sL https://github.com/triggermesh/knative-lambda-runtime/archive/\${RUNTIME_VERSION}.tar.gz | tar -xz knative-lambda-runtime-\${RUNTIME_VERSION}/node-10.x \
-          && mv knative-lambda-runtime-\${RUNTIME_VERSION}/node-10.x/* .
-
-        ENV LAMBDA_TASK_ROOT "/opt"
+        FROM gcr.io/triggermesh/knative-lambda-node10
         ENV _HANDLER "${HANDLER}"
 
         COPY . .

--- a/node-4.x/Dockerfile
+++ b/node-4.x/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:4-alpine
+WORKDIR /opt
+
+RUN apk --no-cache add curl \
+    && API_VERSION=\$(curl -sI https://github.com/triggermesh/aws-custom-runtime/releases/latest | grep "Location:" | awk -F "/" '{print \$NF}' | tr -d "\r") \
+    && RUNTIME_VERSION=\$(curl -sI https://github.com/triggermesh/knative-lambda-runtime/releases/latest | grep "Location:" | awk -F "/" '{print \$NF}' | tr -d "\r") \
+    && curl -sL https://github.com/triggermesh/aws-custom-runtime/releases/download/\${API_VERSION}/aws-custom-runtime > aws-custom-runtime \
+    && chmod +x aws-custom-runtime \
+    && curl -sL https://github.com/triggermesh/knative-lambda-runtime/archive/\${RUNTIME_VERSION}.tar.gz | tar -xz knative-lambda-runtime-\${RUNTIME_VERSION}/node-4.x \
+    && mv knative-lambda-runtime-\${RUNTIME_VERSION}/node-4.x/* .
+
+ENV LAMBDA_TASK_ROOT "/opt"

--- a/node-4.x/buildtemplate.yaml
+++ b/node-4.x/buildtemplate.yaml
@@ -38,18 +38,7 @@ spec:
     - |
       cd /workspace/${DIRECTORY}
       cat <<EOF > Dockerfile
-        FROM node:4-alpine
-        WORKDIR /opt
-
-        RUN apk --no-cache add curl \
-          && API_VERSION=\$(curl -sI https://github.com/triggermesh/aws-custom-runtime/releases/latest | grep "Location:" | awk -F "/" '{print \$NF}' | tr -d "\r") \
-          && RUNTIME_VERSION=\$(curl -sI https://github.com/triggermesh/knative-lambda-runtime/releases/latest | grep "Location:" | awk -F "/" '{print \$NF}' | tr -d "\r") \
-          && curl -sL https://github.com/triggermesh/aws-custom-runtime/releases/download/\${API_VERSION}/aws-custom-runtime > aws-custom-runtime \
-          && chmod +x aws-custom-runtime \
-          && curl -sL https://github.com/triggermesh/knative-lambda-runtime/archive/\${RUNTIME_VERSION}.tar.gz | tar -xz knative-lambda-runtime-\${RUNTIME_VERSION}/node-4.x \
-          && mv knative-lambda-runtime-\${RUNTIME_VERSION}/node-4.x/* .
-
-        ENV LAMBDA_TASK_ROOT "/opt"
+        FROM gcr.io/triggermesh/knative-lambda-node4
         ENV _HANDLER "${HANDLER}"
 
         COPY . .

--- a/python-2.7/Dockerfile
+++ b/python-2.7/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:2.7-alpine
+WORKDIR /opt
+
+RUN apk --no-cache add curl \
+    && API_VERSION=\$(curl -sI https://github.com/triggermesh/aws-custom-runtime/releases/latest | grep "Location:" | awk -F "/" '{print \$NF}' | tr -d "\r") \
+    && RUNTIME_VERSION=\$(curl -sI https://github.com/triggermesh/knative-lambda-runtime/releases/latest | grep "Location:" | awk -F "/" '{print \$NF}' | tr -d "\r") \
+    && curl -sL https://github.com/triggermesh/aws-custom-runtime/releases/download/\${API_VERSION}/aws-custom-runtime > aws-custom-runtime \
+    && chmod +x aws-custom-runtime \
+    && curl -sL https://github.com/triggermesh/knative-lambda-runtime/archive/\${RUNTIME_VERSION}.tar.gz | tar -xz knative-lambda-runtime-\${RUNTIME_VERSION}/python-2.7 \
+    && mv knative-lambda-runtime-\${RUNTIME_VERSION}/python-2.7/* .
+
+ENV LAMBDA_TASK_ROOT "/opt"

--- a/python-2.7/buildtemplate.yaml
+++ b/python-2.7/buildtemplate.yaml
@@ -38,18 +38,8 @@ spec:
     - |
       cd /workspace/${DIRECTORY}
       cat <<EOF > Dockerfile
-        FROM python:2.7-alpine
-        WORKDIR /opt
+        FROM gcr.io/triggermesh/knative-lambda-python27
 
-        RUN apk --no-cache add curl \
-          && API_VERSION=\$(curl -sI https://github.com/triggermesh/aws-custom-runtime/releases/latest | grep "Location:" | awk -F "/" '{print \$NF}' | tr -d "\r") \
-          && RUNTIME_VERSION=\$(curl -sI https://github.com/triggermesh/knative-lambda-runtime/releases/latest | grep "Location:" | awk -F "/" '{print \$NF}' | tr -d "\r") \
-          && curl -sL https://github.com/triggermesh/aws-custom-runtime/releases/download/\${API_VERSION}/aws-custom-runtime > aws-custom-runtime \
-          && chmod +x aws-custom-runtime \
-          && curl -sL https://github.com/triggermesh/knative-lambda-runtime/archive/\${RUNTIME_VERSION}.tar.gz | tar -xz knative-lambda-runtime-\${RUNTIME_VERSION}/python-2.7 \
-          && mv knative-lambda-runtime-\${RUNTIME_VERSION}/python-2.7/* .
-
-        ENV LAMBDA_TASK_ROOT "/opt"
         ENV _HANDLER "${HANDLER}"
 
         COPY . .

--- a/python-3.7/Dockerfile
+++ b/python-3.7/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:alpine3.7
+WORKDIR /opt
+
+RUN apk --no-cache add curl \
+    && API_VERSION=\$(curl -sI https://github.com/triggermesh/aws-custom-runtime/releases/latest | grep "Location:" | awk -F "/" '{print \$NF}' | tr -d "\r") \
+    && RUNTIME_VERSION=\$(curl -sI https://github.com/triggermesh/knative-lambda-runtime/releases/latest | grep "Location:" | awk -F "/" '{print \$NF}' | tr -d "\r") \
+    && curl -sL https://github.com/triggermesh/aws-custom-runtime/releases/download/\${API_VERSION}/aws-custom-runtime > aws-custom-runtime \
+    && chmod +x aws-custom-runtime \
+    && curl -sL https://github.com/triggermesh/knative-lambda-runtime/archive/\${RUNTIME_VERSION}.tar.gz | tar -xz knative-lambda-runtime-\${RUNTIME_VERSION}/python-3.7 \
+    && mv knative-lambda-runtime-\${RUNTIME_VERSION}/python-3.7/* .
+
+ENV LAMBDA_TASK_ROOT "/opt"
+

--- a/python-3.7/buildtemplate.yaml
+++ b/python-3.7/buildtemplate.yaml
@@ -38,18 +38,8 @@ spec:
     - |
       cd /workspace/${DIRECTORY}
       cat <<EOF > Dockerfile
-        FROM python:alpine3.7
-        WORKDIR /opt
+        FROM gcr.io/triggermesh/knative-lambda-python37
 
-        RUN apk --no-cache add curl \
-          && API_VERSION=\$(curl -sI https://github.com/triggermesh/aws-custom-runtime/releases/latest | grep "Location:" | awk -F "/" '{print \$NF}' | tr -d "\r") \
-          && RUNTIME_VERSION=\$(curl -sI https://github.com/triggermesh/knative-lambda-runtime/releases/latest | grep "Location:" | awk -F "/" '{print \$NF}' | tr -d "\r") \
-          && curl -sL https://github.com/triggermesh/aws-custom-runtime/releases/download/\${API_VERSION}/aws-custom-runtime > aws-custom-runtime \
-          && chmod +x aws-custom-runtime \
-          && curl -sL https://github.com/triggermesh/knative-lambda-runtime/archive/\${RUNTIME_VERSION}.tar.gz | tar -xz knative-lambda-runtime-\${RUNTIME_VERSION}/python-3.7 \
-          && mv knative-lambda-runtime-\${RUNTIME_VERSION}/python-3.7/* .
-
-        ENV LAMBDA_TASK_ROOT "/opt"
         ENV _HANDLER "${HANDLER}"
 
         COPY . .


### PR DESCRIPTION
Move some of the template to separate Dockerfile that we can generate via cloudbuild.

It will speed up image building.