### PR TITLE
CE context headers in Python 3.7 runtime

### DIFF
--- a/python37/lambda_runtime_client.py
+++ b/python37/lambda_runtime_client.py
@@ -61,6 +61,7 @@ class LambdaRuntimeClient(object):
             invoked_function_arn=headers["Lambda-Runtime-Invoked-Function-Arn"],
             deadline_time_in_ms=int(headers["Lambda-Runtime-Deadline-Ms"]),
             client_context=headers["Lambda-Runtime-Client-Context"],
+            cloudevents_context=headers["Lambda-Runtime-Cloudevents-Context"],
             cognito_identity=headers["Lambda-Runtime-Cognito-Identity"],
             event_body=response_body
         )


### PR DESCRIPTION
- `Lambda-Runtime-Cloudevents-Context` header added to the task API to provide additional context,
- Since function's `context` is the root object for AWS Lambda function metadata, Cloudevents context is stored under the dedicated map `ce`, and can be accessed as shown below:
  ```
  def foo(event, context):
    print("CE Type is " + context.ce['type'])
  ``` 

More runtimes support is coming.

Related to triggermesh/function#13
Depends on triggermesh/aws-custom-runtime#32