### PR TITLE
CE context headers in Nodejs 10 runtime

### DIFF
--- a/node10/bootstrap
+++ b/node10/bootstrap
@@ -103,6 +103,10 @@ async function nextInvocation() {
     context.clientContext = JSON.parse(res.headers['lambda-runtime-client-context'])
   }
 
+  if (res.headers['lambda-runtime-cloudevents-context']) {
+    context.ce = JSON.parse(res.headers['lambda-runtime-cloudevents-context'])
+  }
+
   if (res.headers['lambda-runtime-cognito-identity']) {
     context.identity = JSON.parse(res.headers['lambda-runtime-cognito-identity'])
   }


### PR DESCRIPTION
Nodejs runtime support of CE context attributes:
```
...
  code: |
    module.exports.main = async (event, context) => {
      return context.ce.type
    };
```
Python runtime PR: #61
Related to triggermesh/function#13