### PR TITLE
CE context headers in Ruby 25 runtime

### DIFF
--- a/ruby25/Dockerfile
+++ b/ruby25/Dockerfile
@@ -15,6 +15,7 @@ ENV LAMBDA_TASK_ROOT "/opt"
 
 COPY --from=downloader /opt/aws-custom-runtime /opt/
 COPY --from=lambda /var/runtime/lib /opt
+COPY lambda_context.rb /opt/
 
 RUN mv /opt/runtime.rb /opt/bootstrap
 RUN sed -i /opt/lambda_server.rb -e 's|http://127.0.0.1:9001/2018-06-01|http://127.0.0.1/2018-06-01|'

--- a/ruby25/lambda_context.rb
+++ b/ruby25/lambda_context.rb
@@ -1,0 +1,34 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+class LambdaContext
+  attr_reader :aws_request_id, :invoked_function_arn, :log_group_name,
+    :log_stream_name, :function_name, :memory_limit_in_mb, :function_version,
+    :identity, :client_context, :ce, :deadline_ms
+
+  def initialize(request)
+    @clock_diff = Process.clock_gettime(Process::CLOCK_REALTIME, :millisecond) - Process.clock_gettime(Process::CLOCK_MONOTONIC, :millisecond)
+    @deadline_ms = request['Lambda-Runtime-Deadline-Ms'].to_i
+    @aws_request_id = request['Lambda-Runtime-Aws-Request-Id']
+    @invoked_function_arn = request['Lambda-Runtime-Invoked-Function-Arn']
+    @log_group_name = ENV['AWS_LAMBDA_LOG_GROUP_NAME']
+    @log_stream_name = ENV['AWS_LAMBDA_LOG_STREAM_NAME']
+    @function_name = ENV["AWS_LAMBDA_FUNCTION_NAME"]
+    @memory_limit_in_mb = ENV['AWS_LAMBDA_FUNCTION_MEMORY_SIZE']
+    @function_version = ENV['AWS_LAMBDA_FUNCTION_VERSION']
+    if request['Lambda-Runtime-Cognito-Identity']
+      @identity = JSON.parse(request['Lambda-Runtime-Cognito-Identity'])
+    end
+    if request['Lambda-Runtime-Client-Context']
+      @client_context = JSON.parse(request['Lambda-Runtime-Client-Context'])
+    end
+    if request['Lambda-Runtime-Cloudevents-Context']
+      @ce = JSON.parse(request['Lambda-Runtime-Cloudevents-Context'])
+    end
+  end
+
+  def get_remaining_time_in_millis
+    now = Process.clock_gettime(Process::CLOCK_MONOTONIC, :millisecond) + @clock_diff
+    remaining = @deadline_ms - now
+    remaining > 0 ? remaining : 0
+  end
+end


### PR DESCRIPTION
CE context attributes passed into AWS Lambda context object:

```
  code: |
    def endpoint(event:, context:)
    context.ce['type']
    end
```

Python runtime PR: #61
Nodejs runtime PR: #62
Related to triggermesh/function#13