### PR TITLE
Update Python, NodeJS and Ruby to the latest AWS Lambda versions

### DIFF
--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -21,11 +21,14 @@ jobs:
       matrix:
         include:
         - runtime: java8
-        - runtime: node10
         - runtime: node4
+        - runtime: node10
+        - runtime: node18
         - runtime: python27
         - runtime: python37
+        - runtime: python310
         - runtime: ruby25
+        - runtime: ruby32
 
     steps:
     - name: Checkout

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 REPO               = knative-lambda-runtime
 REPO_DESC          = TriggerMesh Knative Lambda Runtime
-RUNTIMES           = java8 node10 node4 python27 python37 ruby25
+RUNTIMES           = java8 node10 node4 node18 python27 python37 python310 ruby25 ruby32
 
 BASE_DIR          ?= $(CURDIR)
 

--- a/node18/.dockerignore
+++ b/node18/.dockerignore
@@ -1,0 +1,5 @@
+Dockerfile
+.dockerignore
+
+**/*.md
+**/.gitignore

--- a/node18/Dockerfile
+++ b/node18/Dockerfile
@@ -1,0 +1,16 @@
+FROM alpine as downloader
+
+RUN apk --no-cache add curl \
+ && DOWNLOAD_URL=$(curl -sSf https://api.github.com/repos/triggermesh/aws-custom-runtime/releases/latest | grep "browser_download_url.*-linux-amd64" | cut -d: -f 2,3 | tr -d \") \
+ && curl -sSfL ${DOWNLOAD_URL} -o /opt/aws-custom-runtime \
+ && chmod +x /opt/aws-custom-runtime
+
+FROM amazon/aws-lambda-nodejs:18
+
+WORKDIR /opt
+
+RUN mv /var/runtime/bootstrap /opt
+
+COPY --from=downloader /opt/aws-custom-runtime /opt/
+
+ENV LAMBDA_TASK_ROOT "/opt"

--- a/python310/.dockerignore
+++ b/python310/.dockerignore
@@ -1,0 +1,5 @@
+Dockerfile
+.dockerignore
+
+**/*.md
+**/.gitignore

--- a/python310/Dockerfile
+++ b/python310/Dockerfile
@@ -1,0 +1,22 @@
+FROM alpine as downloader
+
+RUN apk --no-cache add curl git \
+ && DOWNLOAD_URL=$(curl -sSf https://api.github.com/repos/triggermesh/aws-custom-runtime/releases/latest | grep "browser_download_url.*-linux-amd64" | cut -d: -f 2,3 | tr -d \") \
+ && curl -sSfL ${DOWNLOAD_URL} -o /opt/aws-custom-runtime \
+ && chmod +x /opt/aws-custom-runtime \
+ && git clone https://github.com/triggermesh/eventstore-python-client.git /opt/client
+
+FROM amazon/aws-lambda-python:3.10
+
+WORKDIR /opt
+
+RUN pip install --upgrade pip \
+ && pip install grpcio grpcio-tools
+
+RUN mv /var/runtime/bootstrap /opt
+
+COPY --from=downloader /opt/client/eventstore /opt/eventstore
+COPY --from=downloader /opt/aws-custom-runtime /opt/
+
+ENV PYTHONPATH "/opt/eventstore"
+ENV LAMBDA_TASK_ROOT "/opt"

--- a/ruby32/.dockerignore
+++ b/ruby32/.dockerignore
@@ -1,0 +1,5 @@
+Dockerfile
+.dockerignore
+
+**/*.md
+**/.gitignore

--- a/ruby32/Dockerfile
+++ b/ruby32/Dockerfile
@@ -1,0 +1,17 @@
+FROM alpine as downloader
+
+RUN apk --no-cache add curl \
+ && DOWNLOAD_URL=$(curl -sSf https://api.github.com/repos/triggermesh/aws-custom-runtime/releases/latest | grep "browser_download_url.*-linux-amd64" | cut -d: -f 2,3 | tr -d \") \
+ && curl -sSfL ${DOWNLOAD_URL} -o /opt/aws-custom-runtime \
+ && chmod +x /opt/aws-custom-runtime
+
+FROM amazon/aws-lambda-ruby:3.2
+
+WORKDIR /opt
+
+RUN mv /var/runtime/bootstrap /opt
+
+COPY --from=downloader /opt/aws-custom-runtime /opt/
+
+ENV RUBYLIB "/opt"
+ENV LAMBDA_TASK_ROOT "/opt"


### PR DESCRIPTION
New runtimes:

- Python 3.10
- NodeJS 18
- Ruby 3.2

New runtimes based on the official AWS Lambda images with the custom wrapper to expose internal/external APIs and translate to CloudEvents format. No "repacking" ensures full AWS Lambda compatibility but result in bigger base images.