### PR TITLE
KLR images registry fix

### DIFF
--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -50,7 +50,7 @@ jobs:
       id: meta
       uses: docker/metadata-action@v4
       with:
-        images: gcr.io/triggermesh/sameer/knative-lambda-${{ matrix.runtime }}
+        images: gcr.io/triggermesh/knative-lambda-${{ matrix.runtime }}
         tags: |
           type=semver,pattern={{raw}}
           type=sha,prefix=,suffix=,format=long


### PR DESCRIPTION
KLR images were pushed to the registry path that didn't match the expected Function adapter images.
Also, CI cannot finish the release pipeline because of the missing `TM_TRIGGERMESH_TOKEN` secret. I suspect that creating this secret also won't help because direct pushes to the protected main branch are not allowed. 